### PR TITLE
A minor update dnn_filterbank_config.py

### DIFF
--- a/SleepEDF/tensorflow_net/dnn-filterbank/dnn_filterbank_config.py
+++ b/SleepEDF/tensorflow_net/dnn-filterbank/dnn_filterbank_config.py
@@ -31,8 +31,8 @@ class Config(object):
         self.n_hidden_3 = 512  # nb of neurons inside the neural network
 
         # parameters to generate triangular filterbank shape matrix
-        self.nfilter = 20
-        self.f_min = 0
-        self.f_max = 50
-        self.f_high = 50
-        self.f_low = 0
+        self.nfilter = 20       
+        self.fmin = 0
+        self.fmax = 50
+        self.fhigh = 50
+        self.flow = 0


### PR DESCRIPTION
In dnn_filterbank.py line 19, the config is called without any underline for the four last items.

        self.Wbl = tf.constant(self.tri_filter_shape(self.config.n_dim,
                                                     self.config.nfilter,
                                                     self.config.fmin,
                                                     self.config.fmax,
                                                     self.config.flow,
                                                     self.config.fhigh), dtype=tf.float32, name="W-filter-shape")